### PR TITLE
Friend Access added

### DIFF
--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -5,9 +5,15 @@ contract SolidityTest
    uint my_timestamp;  // after how many time the time capsule will open
    string my_info;   // info of time capsule here it is string which we will improve
    address makers_address; // time capsule makers address
+   mapping(address => bool) friends;
 
    modifier check_address() {
-      require (msg.sender == makers_address);  // only maker can access the time capsule
+      require (friends[msg.sender]);  // only maker can access the time capsule
+         _;
+   }
+
+   modifier is_owner() {
+      require (msg.sender==makers_address); 
          _;
    }
 
@@ -24,7 +30,14 @@ contract SolidityTest
 
    function recieve_data (string memory info) public{
       my_info = info ;  // recieve info from frontend
+      makers_address = msg.sender;
+      friends[makers_address] = true;
    } 
+
+   function add_friend (address friend_addr) public is_owner {
+       friends[friend_addr] = true;
+   }
+   
    function show_data () public view correct_time check_address returns(string memory info)  {
       info = my_info;  // returns the info 
    }


### PR DESCRIPTION
The issue #3 of having access for friends is sorted. Modified the `check_address` modifier to check the address from a mapping `friends`.  Also then added a separate `is_owner` modifier to check for the creator of the time capsule. Created a separate function too for adding friends in the list which can only be done by the creator. Moreover, the maker_address was not being set when the time capsule is initialized with the `receive_data` function. So modified that as well to set the maker_address and the friends mapping for the owner.  